### PR TITLE
[REF] Make it work in the case of delivery slip having the column HS Code

### DIFF
--- a/stock_picking_report_valued/report/stock_picking_report_valued.xml
+++ b/stock_picking_report_valued/report/stock_picking_report_valued.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
 
-    <template id="valued_report_picking" inherit_id="stock.report_delivery_document">
+    <template
+        id="valued_report_picking"
+        inherit_id="stock.report_delivery_document"
+        priority="17"
+    >
         <xpath expr="//div[hasclass('page')]" position="before">
             <t t-set="is_outgoing" t-value="o.picking_type_code == 'outgoing'" />
         </xpath>
@@ -10,9 +14,6 @@
             position="inside"
         >
             <t t-if="o.valued and o.sale_id and o.move_line_ids and is_outgoing">
-                <t t-if="o.state != 'done'">
-                    <th class="text-end"><strong>Qty Reserved</strong></th>
-                </t>
                 <th class="text-end"><strong>Unit Price</strong></th>
                 <th class="text-end" groups="product.group_discount_per_so_line">
                     <strong>Discount</strong>
@@ -92,18 +93,9 @@
     <template
         id="valued_report_picking_has_serial_move_line"
         inherit_id="stock.stock_report_delivery_has_serial_move_line"
+        priority="17"
     >
-        <xpath expr="//td[@name='move_line_lot_qty_done']" position="after">
-            <t t-if="move_line.picking_id.state != 'done'">
-                    <td class="text-end">
-                        <span t-field="move_line.product_uom_qty" />
-                        <span t-field="move_line.product_uom_id" /></td>
-                </t>
-                <t t-elif="move_line.picking_id.state == 'done'">
-                    <td class="text-center">
-                        <span t-field="move_line.qty_done" />
-                        <span t-field="move_line.product_uom_id" /></td>
-                </t>
+        <xpath expr="." position="inside">
             <t t-if="o.valued and o.sale_id and o.move_line_ids and is_outgoing">
                 <td class="text-end"><span t-field="move_line.sale_price_unit" /></td>
                 <td class="text-end" groups="product.group_discount_per_so_line">
@@ -116,13 +108,6 @@
                         t-field="move_line.sale_tax_description"
                     /></td>
             </t>
-        </xpath>
-        <xpath expr="//td[@name='move_line_lot_qty_done']" position="attributes">
-            <attribute
-                name="t-if"
-                add="not (o.valued or o.sale_id or o.move_line_ids or is_outgoing)"
-                separator=" "
-            />
         </xpath>
     </template>
 


### PR DESCRIPTION
# Result
- Having both Lot Number and HS code
![hscode-lot](https://github.com/nguyenminhchien/stock-logistics-reporting/assets/8724793/b25a29d4-7ad5-45ff-ab15-9689cf428236)

- Having Lot but no HS Code
![lot-no-hscode](https://github.com/nguyenminhchien/stock-logistics-reporting/assets/8724793/873a2055-f6a2-4da8-b8da-321cc09ba77c)

- Having HS code but no Lot
![hscode-no-lot](https://github.com/nguyenminhchien/stock-logistics-reporting/assets/8724793/cc49b284-1279-4f2d-abc6-89a6e198428e)


- No Lot nor HS code
![no-lot-no-hscode](https://github.com/nguyenminhchien/stock-logistics-reporting/assets/8724793/17ff9ec0-ec82-4fc5-9333-b5d4b9ce271f)
